### PR TITLE
fix: expose root agent

### DIFF
--- a/prompt_validation_agent/__init__.py
+++ b/prompt_validation_agent/__init__.py
@@ -1,1 +1,15 @@
-from . import agent
+"""Expose the package's root agent.
+
+The ADK expects each agent package to expose a ``root_agent`` object at the
+package level.  The previous implementation only imported the ``agent`` module
+which forced consumers to access ``prompt_validation_agent.agent.root_agent``.
+This made agent discovery fail in contexts that expect the variable to be
+available directly on the package.  By importing ``root_agent`` here we make it
+available as ``prompt_validation_agent.root_agent`` and restore the expected
+behaviour.
+"""
+
+from .agent import root_agent
+
+__all__ = ["root_agent"]
+


### PR DESCRIPTION
## Summary
- ensure root agent is exported from package for ADK discovery

## Testing
- `python -m py_compile prompt_validation_agent/__init__.py prompt_validation_agent/agent.py`
- `python - <<'PY'
import prompt_validation_agent
print(hasattr(prompt_validation_agent, 'root_agent'))
print(type(prompt_validation_agent.root_agent).__name__)
PY`


------
https://chatgpt.com/codex/tasks/task_e_688ee5d35aa8832d983769b42ca63998